### PR TITLE
Don't include React in webpack bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,4 +10,8 @@ module.exports = {
 	    { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"}
 	  ]
 	}
+	externals: {
+  		'react': 'react',
+  		'react-dom': 'react-dom'
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	  loaders: [
 	    { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"}
 	  ]
-	}
+	},
 	externals: {
   		'react': 'react',
   		'react-dom': 'react-dom'


### PR DESCRIPTION
Hey, it [looks like](https://github.com/zeit/next.js/issues/1975#issuecomment-301685934) this component is including it's own copy of React instead of using the one from whatever code imports it. This causes various issues, such as triggering a development-mode warning.

The change here tells webpack to ignore react & react-dom when creating the bundle and just assume that they will be provided externally.